### PR TITLE
Export ReactSortableTree without dnd wrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-import SortableTree from './react-sortable-tree';
+import SortableTree, { UnwrappedSortableTree } from './react-sortable-tree';
 
 export * from './utils/default-handlers';
 export * from './utils/tree-data-utils';
+export { UnwrappedSortableTree };
 export default SortableTree;

--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -545,4 +545,4 @@ ReactSortableTree.defaultProps = {
     isVirtualized: true,
 };
 
-export default dndWrapRoot(ReactSortableTree);
+export default ReactSortableTree;

--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -545,4 +545,6 @@ ReactSortableTree.defaultProps = {
     isVirtualized: true,
 };
 
-export default ReactSortableTree;
+export { ReactSortableTree as UnwrappedSortableTree };
+
+export default dndWrapRoot(ReactSortableTree);


### PR DESCRIPTION
In some cases it is necessary to provide the dnd wrapper explicitly and it would be useful if the plain, unwrapped component would be available as well.

Cf. issue #5 for details.

The name `UnwrappedSortableTree` is up for discussion.