### PR TITLE
[bugfix](Hover): Fix the hover errors

### DIFF
--- a/src/utils/tree-data-utils.js
+++ b/src/utils/tree-data-utils.js
@@ -610,7 +610,8 @@ function addNodeAtDepthAndIndex({
     }
 
     // If the current position is the only possible place to add, add it
-    if (currentIndex >= minimumTreeIndex - 1 || (isLastChild && !node.children)) {
+    if (currentIndex >= minimumTreeIndex - 1
+      || (isLastChild && !(node.children && node.children.length))) {
         if (typeof node.children === 'function') {
             throw new Error('Cannot add to children defined by a function');
         } else {


### PR DESCRIPTION
When you want to drag & drop a node with children and you hover the children you have a lot of errors on the console

-- 1
------2
-----------3

If you drag 2 and hover 3, it will throw
From issue: #40 