### PR TITLE
Allow the tree to drop successfully outside its own scope without cau…

### DIFF
--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -262,7 +262,7 @@ class ReactSortableTree extends Component {
     }
 
     endDrag(dropResult) {
-        if (!dropResult) {
+        if (!dropResult || !dropResult.node) {
             return this.setState({
                 draggingTreeData: null,
                 swapFrom: null,


### PR DESCRIPTION
Allow the tree to drop successfully outside its own scope without causing the internal tree structure to become corrupt.

Use-case: 
If a treeNode gets dropped outside of the tree scope in a valid React-dnd dropZone, we want the tree structure to remain as it was.

Issue:
As the endDrag is still called with a "valid" dropResult (missing the dropResult.node) the tree is left in a state where the visual depiction is different to its internal structure. Checking for the dropResult.node and bailing at this point allows the tree to handle in the same manor as if it was an invalid drop.

Replicate issue:
1. Drag a child treeNode to a valid React-dnd dropZone. (No error)
1.1 The visual tree will leave the treeNode in the top level position of the tree (ie, far left)
1.2 The internal state of the tree will remain how it was prior to the drag

2. Drag the same treeNode to a new position in the tree
2.1 Error treeNode not found at position

3. Any other tree re-rendering will cause the tree to jump to previous state.