### PR TITLE
[JUST A TRY] Drag nodes to insert

### DIFF
--- a/src/examples/basicExample/app.js
+++ b/src/examples/basicExample/app.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import {DragDropContext, DragSource} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { SortableTreeWithoutDndContext as SortableTree, toggleExpandedForAll } from '../../index';
+import { SortableTreeWithoutDndContext as SortableTree, toggleExpandedForAll, dndWrapExternalSource } from '../../index';
 import styles from './stylesheets/app.scss';
 import '../shared/favicon/apple-touch-icon.png';
 import '../shared/favicon/favicon-16x16.png';
@@ -10,26 +10,7 @@ import '../shared/favicon/favicon-32x32.png';
 import '../shared/favicon/favicon.ico';
 import '../shared/favicon/safari-pinned-tab.svg';
 
-const dragSource = {
-  beginDrag(props) {
-    return {node: {...props.node}, path: []}
-  },
-
-  endDrag(props, monitor, component) {
-    if (!monitor.didDrop()) {
-      return
-    }
-  }
-}
-
-function collect (connect, monitor) {
-  return {
-    connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging()
-  }
-}
-
-const Node = DragSource('NEW_NODE', dragSource, collect)(
+const Node = dndWrapExternalSource('NEW_NODE', props => ({node: props.node}))(
 class Node extends Component {
     render () {
         const {connectDragSource} = this.props

--- a/src/examples/basicExample/stylesheets/app.scss
+++ b/src/examples/basicExample/stylesheets/app.scss
@@ -9,6 +9,13 @@
     box-sizing: border-box;
 }
 
+.new-node {
+	display: inline-block;
+	border: solid 1px black;
+	padding: 5px;
+	margin: 5px;
+}
+
 body {
     background-color: #FAFAFA;
     font-family: Arial, Helvetica, sans-serif;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import SortableTree, { SortableTreeWithoutDndContext } from './react-sortable-tree';
+import SortableTree, { SortableTreeWithoutDndContext, dndWrapExternalSource } from './react-sortable-tree';
 
 export * from './utils/default-handlers';
 export * from './utils/tree-data-utils';
@@ -7,4 +7,4 @@ export default SortableTree;
 // Export the tree component without the react-dnd DragDropContext,
 // for when component is used with other components using react-dnd.
 // see: https://github.com/gaearon/react-dnd/issues/186
-export { SortableTreeWithoutDndContext };
+export { SortableTreeWithoutDndContext, dndWrapExternalSource };

--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -277,6 +277,9 @@ class ReactSortableTree extends Component {
     }
 
     endDrag(dropResult) {
+        if (!(dropResult || {}).external) {
+            this.drop(dropResult);
+        }
     }
 
     drop(dropResult) {

--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -34,6 +34,7 @@ import {
     dndWrapRoot,
     dndWrapSource,
     dndWrapTarget,
+    dndWrapExternalSource,
 } from './utils/drag-and-drop-utils';
 import styles from './react-sortable-tree.scss';
 
@@ -598,5 +599,6 @@ ReactSortableTree.defaultProps = {
 // for when component is used with other components using react-dnd.
 // see: https://github.com/gaearon/react-dnd/issues/186
 export { ReactSortableTree as SortableTreeWithoutDndContext };
+export { dndWrapExternalSource };
 
 export default dndWrapRoot(ReactSortableTree);

--- a/src/tree-node.js
+++ b/src/tree-node.js
@@ -18,6 +18,7 @@ class TreeNode extends Component {
             treeIndex,
             customCanDrop: _customCanDrop, // Delete from otherProps
             dragHover:     _dragHover,     // Delete from otherProps
+            drop:          _drop,          // Delete from otherProps
             getNodeKey:    _getNodeKey,    // Delete from otherProps
             getPrevRow:    _getPrevRow,    // Delete from otherProps
             maxDepth:      _maxDepth,      // Delete from otherProps
@@ -159,6 +160,7 @@ TreeNode.propTypes = {
 
     customCanDrop: PropTypes.func,                      // used in drag-and-drop-utils
     dragHover:     PropTypes.func.isRequired,           // used in drag-and-drop-utils
+    drop:          PropTypes.func.isRequired,           // used in drag-and-drop-utils
     getNodeKey:    PropTypes.func,                      // used in drag-and-drop-utils
     getPrevRow:    PropTypes.func,                      // used in drag-and-drop-utils
     maxDepth:      PropTypes.number,                    // used in drag-and-drop-utils

--- a/src/utils/drag-and-drop-utils.js
+++ b/src/utils/drag-and-drop-utils.js
@@ -102,12 +102,14 @@ function canDrop(dropTargetProps, monitor) {
 
 const nodeDropTarget = {
     drop(dropTargetProps, monitor) {
-        return {
+        const dropResults = {
             node:             monitor.getItem().node,
             path:             monitor.getItem().path,
             minimumTreeIndex: dropTargetProps.treeIndex,
             depth:            getTargetDepth(dropTargetProps, monitor),
         };
+        dropTargetProps.drop(dropResults);
+        return dropResults;
     },
 
     hover(dropTargetProps, monitor) {

--- a/src/utils/drag-and-drop-utils.js
+++ b/src/utils/drag-and-drop-utils.js
@@ -167,3 +167,12 @@ export function dndWrapTarget(el, type) {
 export function dndWrapRoot(el) {
     return dragDropContext(HTML5Backend)(el);
 }
+
+export function dndWrapExternalSource(type, spec) {
+    const externalDragSource = {
+        beginDrag(props) {
+            return {path: [], ...spec(props)};
+        },
+    };
+    return dragSource(type, externalDragSource, nodeDragSourcePropInjection);
+}


### PR DESCRIPTION
@fritz-c I try to add a `dndDropTypes` to make the tree accept other dnd types, and process the insertion (IT DOES NOT WORK FINE), is it a way to make it flexible for support https://github.com/fritz-c/react-sortable-tree/issues/60?

Note:
With this commit, it can insert node into the tree, but can't move or insert again. I know it is not correctly processing the data. Just a try.