### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "peerDependencies": {
     "react": "^15.3.0",
-    "react-addons-shallow-compare": "^15.3.0",
     "react-dom": "^15.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
react-addons-shallow-compare was once used in react-virtualized, but no longer.