### PR TITLE
Explicit button type to prevent form submit

### DIFF
--- a/src/node-renderer-default.js
+++ b/src/node-renderer-default.js
@@ -84,6 +84,7 @@ class NodeRendererDefault extends Component {
                 {toggleChildrenVisibility && node.children && node.children.length > 0 && (
                     <div>
                         <button
+                            type="button"
                             aria-label={node.expanded ? 'Collapse' : 'Expand'}
                             className={node.expanded ? styles.collapseButton : styles.expandButton}
                             style={{ left: -0.5 * scaffoldBlockPxWidth }}


### PR DESCRIPTION
In HTML5 Spec, the [button element](https://www.w3.org/TR/2011/WD-html5-20110525/the-button-element.html#the-button-element) has a default behavior to submit the form.

When the tree is inside a form, the expand/collapse button submit the form unintentionally.

This commit fixes it adding `type="button"` explicitly.

If you can merge it fast I would be very grateful 😁  (I need it on another open-source project)

Thanks a lot!