### PR TITLE
Replace a modules and support mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "lodash.isequal": "^4.4.0",
     "react-dnd": "^2.1.4",
-    "react-dnd-html5-backend": "^2.1.2",
     "react-dnd-scrollzone": "^3.1.0",
+    "react-dnd-touch-backend": "^0.3.9",
     "react-virtualized": "^9.3.0"
   },
   "peerDependencies": {

--- a/src/utils/drag-and-drop-utils.js
+++ b/src/utils/drag-and-drop-utils.js
@@ -3,7 +3,7 @@ import {
     DragSource as dragSource,
     DropTarget as dropTarget,
 } from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import TouchBackend  from 'react-dnd-touch-backend';
 import {
     getDepth,
 } from './tree-data-utils';
@@ -166,5 +166,5 @@ export function dndWrapTarget(el, type) {
 }
 
 export function dndWrapRoot(el) {
-    return dragDropContext(HTML5Backend)(el);
+    return dragDropContext(TouchBackend({ enableMouseEvents: true }))(el);
 }


### PR DESCRIPTION
Replace  'react-dnd-html5-backend' to ‘react-dnd-touch-backend’, friendly to moblie and support touch event.