### PR TITLE
Update react-dnd to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash.isequal": "^4.4.0",
-    "react-dnd": "^2.1.4",
+    "react-dnd": "^2.4.0",
     "react-dnd-html5-backend": "^2.1.2",
     "react-dnd-scrollzone": "^3.1.0",
     "react-virtualized": "^9.3.0"


### PR DESCRIPTION
Update `react-dnd` to `2.4.0` to remove `Warning: Accessing PropTypes via the main React package is deprecated` warning and make compatible for React 16

Closes #94 