### PR TITLE
Use custom node key also when isVirtualized=true

### DIFF
--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -368,10 +368,13 @@ class ReactSortableTree extends Component {
                             rowCount={rows.length}
                             estimatedRowSize={typeof rowHeight !== 'function' ? rowHeight : undefined}
                             rowHeight={rowHeight}
-                            rowRenderer={({ index, key, style: rowStyle }) => this.renderRow(
+                            rowRenderer={({ index, style: rowStyle }) => this.renderRow(
                                 rows[index],
                                 index,
-                                key,
+                                getNodeKey({
+                                    node:      rows[index].node,
+                                    treeIndex: rows[index].treeIndex,
+                                }),
                                 rowStyle,
                                 () => (rows[index - 1] || null),
                                 matchKeys


### PR DESCRIPTION
We had plenty of state issues while dynamically adding/removing nodes from the tree and noticed that it's caused by the key prop. Adding a custom ``getNodeKey`` method works fine when ``isVirtualized=false`` but isn't honored when ``isVirtualized=true``.