### PR TITLE
Drag in External Nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "scripts": {
     "build": "npm run clean && cross-env NODE_ENV=production webpack --config webpack.config.umd.babel.js --bail",
     "build:demo": "npm run clean:demo && cross-env NODE_ENV=production webpack --config webpack.config.demo.babel.js --bail",
+    "build:external": "npm run clean:demo && cross-env NODE_ENV=production webpack --config webpack.config.external.babel.js --bail",
     "clean": "rimraf dist/umd",
     "clean:demo": "rimraf build",
+    "clean:external": "rimraf build",
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --config webpack.config.dev.babel.js",
+    "external-nodes-demo": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --config webpack.config.dev-external.babel.js",
     "lint": "eslint src",
     "prepublishOnly": "npm run lint && npm run test && npm run build",
     "test": "cross-env NODE_ENV=test karma start --single-run",

--- a/src/examples/externalNodeExample/ExternalNode.js
+++ b/src/examples/externalNodeExample/ExternalNode.js
@@ -1,0 +1,17 @@
+import React, { Component} from 'react';
+import PropTypes from 'prop-types'
+import styles from './stylesheets/app.scss';
+import { dndWrapExternalSource } from './../../index'
+
+class ExternalNode extends Component {
+  render() {
+    return (<div className={styles['external-node']}>{this.props.node.title}</div>);
+  }
+}
+
+ExternalNode.propTypes = {
+  node: PropTypes.shape({ title:PropTypes.string }).isRequired
+}
+
+
+export default dndWrapExternalSource(ExternalNode, 'NEW_NODE');

--- a/src/examples/externalNodeExample/app.js
+++ b/src/examples/externalNodeExample/app.js
@@ -1,0 +1,366 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { SortableTreeWithoutDndContext as SortableTree, toggleExpandedForAll } from '../../index';
+import styles from './stylesheets/app.scss';
+import ExternalNode from './ExternalNode';
+import {
+  defaultGetNodeKey,
+} from './../../utils/default-handlers';
+import {
+  insertNode,
+} from './../../utils/tree-data-utils';
+
+import '../shared/favicon/apple-touch-icon.png';
+import '../shared/favicon/favicon-16x16.png';
+import '../shared/favicon/favicon-32x32.png';
+import '../shared/favicon/favicon.ico';
+import '../shared/favicon/safari-pinned-tab.svg';
+
+// example of external node objects
+const newNodes = [
+  { title: 'Just a title' },
+  { title: 'Title with subtitle', subtitle: 'This is a subtitle' },
+  { title: 'Another External Node', subtitle: 'another subtitle' },
+];
+
+const maxDepth = 5;
+
+const App = DragDropContext(HTML5Backend)(
+  class App extends Component {
+    constructor(props) {
+      super(props);
+
+      const renderDepthTitle = ({ path }) => `Depth: ${path.length}`;
+
+      this.state = {
+        searchString: '',
+        searchFocusIndex: 0,
+        searchFoundCount: null,
+        treeData: [
+          {
+            title: '`title`',
+            subtitle: '`subtitle`',
+            expanded: true,
+            children: [
+              {
+                title: 'Child Node',
+                subtitle: 'Defined in `children` array belonging to parent',
+              },
+              {
+                title: 'Nested structure is rendered virtually',
+                subtitle: (
+                  <span>
+                    The tree uses&nbsp;
+                    <a href="https://github.com/bvaughn/react-virtualized">
+                      react-virtualized
+                    </a>
+                    &nbsp;and the relationship lines are more of a visual trick.
+                  </span>
+                ),
+              },
+            ],
+          },
+          {
+            expanded: true,
+            title: 'Any node can be the parent or child of any other node',
+            children: [
+              {
+                expanded: true,
+                title: 'Chicken',
+                children: [
+                  { title: 'Egg' },
+                ],
+              },
+            ],
+          },
+          {
+            title: 'Button(s) can be added to the node',
+            subtitle: 'Node info is passed when generating so you can use it in your onClick handler',
+          },
+          {
+            title: 'Show node children by setting `expanded`',
+            subtitle: ({ node }) => `expanded: ${node.expanded ? 'true' : 'false'}`,
+            children: [
+              {
+                title: 'Bruce',
+                subtitle: ({ node }) => `expanded: ${node.expanded ? 'true' : 'false'}`,
+                children: [
+                  { title: 'Bruce Jr.' },
+                  { title: 'Brucette' },
+                ],
+              },
+            ],
+          },
+          {
+            title: 'Advanced',
+            subtitle: 'Settings, behavior, etc.',
+            children: [
+              {
+                title: (
+                  <div>
+                    <div
+                      style={{
+                        backgroundColor: 'gray',
+                        display: 'inline-block',
+                        borderRadius: 10,
+                        color: '#FFF',
+                        padding: '0 5px',
+                      }}
+                    >
+                      Any Component
+                    </div>
+                    &nbsp;can be used for `title`
+                  </div>
+                ),
+              },
+              {
+                expanded: true,
+                title: 'Limit nesting with `maxDepth`',
+                subtitle: `It's set to ${maxDepth} for this example`,
+                children: [
+                  {
+                    expanded: true,
+                    title: renderDepthTitle,
+                    children: [
+                      {
+                        expanded: true,
+                        title: renderDepthTitle,
+                        children: [
+                          { title: renderDepthTitle },
+                          {
+                            title: ({ path }) => (path.length >= maxDepth ?
+                              'This cannot be dragged deeper' :
+                              'This can be dragged deeper'
+                            ),
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                title: 'Disable dragging on a per-node basis with the `canDrag` prop',
+                subtitle: 'Or set it to false to disable all dragging.',
+                noDragging: true,
+              },
+              {
+                title: 'You cannot give this children',
+                subtitle: 'Dropping is prevented via the `canDrop` API using `nextParent`',
+                noChildren: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      this.updateTreeData = this.updateTreeData.bind(this);
+      this.expandAll = this.expandAll.bind(this);
+      this.collapseAll = this.collapseAll.bind(this);
+      this.addItem = this.addItem.bind(this);
+      this.dropCancelled = this.dropCancelled.bind(this);
+    }
+
+    updateTreeData(treeData) {
+      this.setState({ treeData });
+    }
+
+    expand(expanded) {
+      this.setState({
+        treeData: toggleExpandedForAll({
+          treeData: this.state.treeData,
+          expanded,
+        }),
+      });
+    }
+
+    expandAll() {
+      this.expand(true);
+    }
+
+    collapseAll() {
+      this.expand(false);
+    }
+    addItem(newItem) {
+      const { treeData } = insertNode({
+        treeData: this.state.treeData,
+        newNode: newItem.node,
+        depth: newItem.depth,
+        minimumTreeIndex: newItem.minimumTreeIndex,
+        expandParent: true,
+        getNodeKey: defaultGetNodeKey,
+      });
+      this.setState({ treeData });
+    }
+    dropCancelled() {
+      this.setState({ treeData: this.state.treeData.map(item => ({ ...item, update: Math.random() })) });
+    }
+    render() {
+      const projectName = 'React Sortable Tree - Adding External Nodes';
+      const authorName = 'Chris Fritz';
+      const authorUrl = 'https://github.com/fritz-c';
+      const githubUrl = 'https://github.com/fritz-c/react-sortable-tree';
+
+      const {
+        treeData,
+        searchString,
+        searchFocusIndex,
+        searchFoundCount,
+      } = this.state;
+
+      const alertNodeInfo = ({
+        node,
+        path,
+        treeIndex,
+        }) => {
+        const objectString = Object.keys(node)
+          .map(k => (k === 'children' ? 'children: Array' : `${k}: '${node[k]}'`))
+          .join(',\n   ');
+
+        alert( // eslint-disable-line no-alert
+          'Info passed to the button generator:\n\n' +
+          `node: {\n   ${objectString}\n},\n` +
+          `path: [${path.join(', ')}],\n` +
+          `treeIndex: ${treeIndex}`
+        );
+      };
+
+      const selectPrevMatch = () => this.setState({
+        searchFocusIndex: searchFocusIndex !== null ?
+          ((searchFoundCount + searchFocusIndex - 1) % searchFoundCount) :
+          searchFoundCount - 1,
+      });
+
+      const selectNextMatch = () => this.setState({
+        searchFocusIndex: searchFocusIndex !== null ?
+          ((searchFocusIndex + 1) % searchFoundCount) :
+          0,
+      });
+
+      const isVirtualized = true;
+      const treeContainerStyle = isVirtualized ? { height: 450, width: 675, padding: 10 } : {};
+
+      return (
+        <div>
+          <section className={styles['page-header']}>
+            <h1 className={styles['project-name']}>{projectName}</h1>
+
+            <h2 className={styles['project-tagline']}>
+              Drag-and-drop sortable representation of hierarchical data
+                    </h2>
+          </section>
+
+          <section className={styles['main-content']}>
+            <h3>External Nodes Demo</h3>
+            <div style={{display: 'flex'}}>
+              <div style={{flexGrow:1}}>
+                <button onClick={this.expandAll}>
+                  Expand All
+                </button>
+                <button onClick={this.collapseAll}>
+                  Collapse All
+                </button>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                <form
+                  style={{ display: 'inline-block' }}
+                  onSubmit={(event) => { event.preventDefault(); }}>
+                  <label htmlFor="find-box">
+                    Search:&nbsp;
+                    <input
+                      id="find-box"
+                      type="text"
+                      value={searchString}
+                      onChange={event => this.setState({ searchString: event.target.value })}
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    disabled={!searchFoundCount}
+                    onClick={selectPrevMatch}
+                  >
+                    &lt;
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={!searchFoundCount}
+                    onClick={selectNextMatch}
+                  >
+                    &gt;
+                  </button>
+                  <span>
+                    &nbsp;
+                      {searchFoundCount > 0 ? (searchFocusIndex + 1) : 0}
+                    &nbsp;/&nbsp;
+                      {searchFoundCount || 0}
+                  </span>
+                </form>
+                <div style={treeContainerStyle}>
+                  <SortableTree
+                    treeData={treeData}
+                    dndType="NEW_NODE"
+                    onChange={this.updateTreeData}
+                    onMoveNode={({ node, treeIndex, path }) =>
+                      console.debug( // eslint-disable-line no-console
+                        'node:', node,
+                        'treeIndex:', treeIndex,
+                        'path:', path,
+                      )
+                    }
+                    maxDepth={maxDepth}
+                    searchQuery={searchString}
+                    searchFocusOffset={searchFocusIndex}
+                    canDrag={({ node }) => !node.noDragging}
+                    canDrop={({ nextParent }) => !nextParent || !nextParent.noChildren}
+                    searchFinishCallback={matches =>
+                      this.setState({
+                        searchFoundCount: matches.length,
+                        searchFocusIndex: matches.length > 0 ? searchFocusIndex % matches.length : 0,
+                      })
+                    }
+                    isVirtualized={isVirtualized}
+                    generateNodeProps={rowInfo => ({
+                      buttons: [
+                        <button style={{ verticalAlign: 'middle' }} onClick={() => alertNodeInfo(rowInfo)}>
+                          ℹ
+                        </button>,
+                      ],
+                    })}
+                  />
+                </div>
+                <a href={githubUrl}>Documentation on Github</a>
+                <footer className={styles['site-footer']}>
+                  <span className={styles['site-footer-owner']}>
+                    <a href={githubUrl}>{projectName}</a> is maintained by <a href={authorUrl}>{authorName}</a>.
+                  </span>
+                  <span className={styles['site-footer-credits']}>
+                    This page was generated by <a href="https://pages.github.com">GitHub Pages</a> using the <a href="https://github.com/jasonlong/cayman-theme">Cayman theme</a> by <a href="https://twitter.com/jasonlong">Jason Long</a>.
+                  </span>
+                </footer>
+              </div>
+              <div style={{padding:10, flexGrow:1}}>
+                <p>Drag nodes below into the tree and drop to add.</p>
+                <div className={styles['external-node-container']}>
+                    {newNodes.map((node, index) =>
+                      // simple trick for passing react/no-array-index-key eslint rule
+                      <ExternalNode key={`externalNode-${index + 1}`} node={node} addNewItem={this.addItem} dropCancelled={this.dropCancelled} />
+                    )}
+                </div>
+              </div>
+            </div>
+          </section>
+          <a href={githubUrl}>
+            <img
+              style={{ position: 'absolute', top: 0, right: 0, border: 0 }}
+              src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
+              alt="Fork me on GitHub"
+              data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
+            />
+          </a>
+        </div>
+      );
+    }
+  });
+
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/src/examples/externalNodeExample/index.html
+++ b/src/examples/externalNodeExample/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en-us">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Adding External Nodes</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="apple-touch-icon" sizes="180x180" href="static/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="static/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="static/favicon-16x16.png" sizes="16x16">
+  <link rel="mask-icon" href="static/safari-pinned-tab.svg" color="#de7a32">
+  <link rel="shortcut icon" href="static/favicon.ico">
+  <meta name="theme-color" content="#ffffff">
+</head>
+
+<body>
+  <div id="app"></div>
+</body>
+
+</html>

--- a/src/examples/externalNodeExample/stylesheets/app.scss
+++ b/src/examples/externalNodeExample/stylesheets/app.scss
@@ -1,0 +1,40 @@
+@import "./vendor/stylesheet";
+@import "./vendor/github-light";
+
+.page-header {
+    padding: 1rem 6rem;
+}
+
+.main-content {
+    box-sizing: border-box;
+}
+
+.external-node {
+	display: flex;
+	flex-basis: auto;
+	border: solid 1px black;
+	width: 175px;
+	padding: 5px;
+	margin: 5px;
+}
+
+.external-node-container {
+	padding: 20px;    
+	margin: 5px;
+}
+
+body {
+    background-color: #FAFAFA;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+/**
+ * Uncomment to simulate bootstrap environment
+ */
+// html {
+//     box-sizing: border-box;
+// }
+
+// *, *::before, *::after {
+//     box-sizing: inherit;
+// }

--- a/src/examples/externalNodeExample/stylesheets/vendor/github-light.css
+++ b/src/examples/externalNodeExample/stylesheets/vendor/github-light.css
@@ -1,0 +1,116 @@
+/*
+   Copyright 2014 GitHub Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+.pl-c /* comment */ {
+  color: #969896;
+}
+
+.pl-c1      /* constant, markup.raw, meta.diff.header, meta.module-reference, meta.property-name, support, support.constant, support.variable, variable.other.constant */,
+.pl-s .pl-v /* string variable */ {
+  color: #0086b3;
+}
+
+.pl-e  /* entity */,
+.pl-en /* entity.name */ {
+  color: #795da3;
+}
+
+.pl-s .pl-s1 /* string source */,
+.pl-smi      /* storage.modifier.import, storage.modifier.package, storage.type.java, variable.other, variable.parameter.function */ {
+  color: #333;
+}
+
+.pl-ent /* entity.name.tag */ {
+  color: #63a35c;
+}
+
+.pl-k /* keyword, storage, storage.type */ {
+  color: #a71d5d;
+}
+
+.pl-pds              /* punctuation.definition.string, string.regexp.character-class */,
+.pl-s                /* string */,
+.pl-s .pl-pse .pl-s1 /* string punctuation.section.embedded source */,
+.pl-sr               /* string.regexp */,
+.pl-sr .pl-cce       /* string.regexp constant.character.escape */,
+.pl-sr .pl-sra       /* string.regexp string.regexp.arbitrary-repitition */,
+.pl-sr .pl-sre       /* string.regexp source.ruby.embedded */ {
+  color: #183691;
+}
+
+.pl-v /* variable */ {
+  color: #ed6a43;
+}
+
+.pl-id /* invalid.deprecated */ {
+  color: #b52a1d;
+}
+
+.pl-ii /* invalid.illegal */ {
+  background-color: #b52a1d;
+  color: #f8f8f8;
+}
+
+.pl-sr .pl-cce /* string.regexp constant.character.escape */ {
+  color: #63a35c;
+  font-weight: bold;
+}
+
+.pl-ml /* markup.list */ {
+  color: #693a17;
+}
+
+.pl-mh        /* markup.heading */,
+.pl-mh .pl-en /* markup.heading entity.name */,
+.pl-ms        /* meta.separator */ {
+  color: #1d3e81;
+  font-weight: bold;
+}
+
+.pl-mq /* markup.quote */ {
+  color: #008080;
+}
+
+.pl-mi /* markup.italic */ {
+  color: #333;
+  font-style: italic;
+}
+
+.pl-mb /* markup.bold */ {
+  color: #333;
+  font-weight: bold;
+}
+
+.pl-md /* markup.deleted, meta.diff.header.from-file */ {
+  background-color: #ffecec;
+  color: #bd2c00;
+}
+
+.pl-mi1 /* markup.inserted, meta.diff.header.to-file */ {
+  background-color: #eaffea;
+  color: #55a532;
+}
+
+.pl-mdr /* meta.diff.range */ {
+  color: #795da3;
+  font-weight: bold;
+}
+
+.pl-mo /* meta.output */ {
+  color: #1d3e81;
+}
+

--- a/src/examples/externalNodeExample/stylesheets/vendor/stylesheet.css
+++ b/src/examples/externalNodeExample/stylesheets/vendor/stylesheet.css
@@ -1,0 +1,134 @@
+body {
+  padding: 0;
+  margin: 0;
+}
+
+.btn {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.3rem;
+  transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
+  .btn + .btn {
+    margin-left: 1rem; }
+
+.btn:hover {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.3); }
+
+@media screen and (min-width: 64em) {
+  .btn {
+    padding: 0.75rem 1rem; } }
+
+@media screen and (min-width: 42em) and (max-width: 64em) {
+  .btn {
+    padding: 0.6rem 0.9rem;
+    font-size: 0.9rem; } }
+
+@media screen and (max-width: 42em) {
+  .btn {
+    display: block;
+    width: 100%;
+    padding: 0.75rem;
+    font-size: 0.9rem; }
+    .btn + .btn {
+      margin-top: 1rem;
+      margin-left: 0; } }
+
+.page-header {
+  color: #fff;
+  text-align: center;
+  background-color: #159957;
+  background-image: linear-gradient(120deg, #155799, #159957); }
+
+@media screen and (min-width: 64em) {
+  .page-header {
+    padding: 5rem 6rem; } }
+
+@media screen and (min-width: 42em) and (max-width: 64em) {
+  .page-header {
+    padding: 3rem 4rem; } }
+
+@media screen and (max-width: 42em) {
+  .page-header {
+    padding: 2rem 1rem; } }
+
+.project-name {
+  margin-top: 0;
+  margin-bottom: 0.1rem; }
+
+@media screen and (min-width: 64em) {
+  .project-name {
+    font-size: 3.25rem; } }
+
+@media screen and (min-width: 42em) and (max-width: 64em) {
+  .project-name {
+    font-size: 2.25rem; } }
+
+@media screen and (max-width: 42em) {
+  .project-name {
+    font-size: 1.75rem; } }
+
+.project-tagline {
+  margin-bottom: 2rem;
+  font-weight: normal;
+  opacity: 0.7; }
+
+@media screen and (min-width: 64em) {
+  .project-tagline {
+    font-size: 1.25rem; } }
+
+@media screen and (min-width: 42em) and (max-width: 64em) {
+  .project-tagline {
+    font-size: 1.15rem; } }
+
+@media screen and (max-width: 42em) {
+  .project-tagline {
+    font-size: 1rem; } }
+
+@media screen and (min-width: 64em) {
+  .main-content {
+    max-width: 64rem;
+    padding: 2rem 6rem;
+    margin: 0 auto;
+    font-size: 1.1rem; } }
+
+@media screen and (min-width: 42em) and (max-width: 64em) {
+  .main-content {
+    padding: 2rem 4rem;
+    font-size: 1.1rem; } }
+
+@media screen and (max-width: 42em) {
+  .main-content {
+    padding: 2rem 1rem;
+    font-size: 1rem; } }
+
+.site-footer {
+  padding-top: 2rem;
+  margin-top: 2rem;
+  border-top: solid 1px #eff0f1; }
+
+.site-footer-owner {
+  display: block;
+  font-weight: bold; }
+
+.site-footer-credits {
+  color: #819198; }
+
+@media screen and (min-width: 64em) {
+  .site-footer {
+    font-size: 1rem; } }
+
+@media screen and (min-width: 42em) and (max-width: 64em) {
+  .site-footer {
+    font-size: 1rem; } }
+
+@media screen and (max-width: 42em) {
+  .site-footer {
+    font-size: 0.9rem; } }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import SortableTree, { SortableTreeWithoutDndContext } from './react-sortable-tr
 
 export * from './utils/default-handlers';
 export * from './utils/tree-data-utils';
+export { dndWrapExternalSource } from './utils/drag-and-drop-utils'
 export default SortableTree;
 
 // Export the tree component without the react-dnd DragDropContext,

--- a/src/react-sortable-tree.test.js
+++ b/src/react-sortable-tree.test.js
@@ -23,6 +23,7 @@ describe('<SortableTree />', () => {
       'render'
     ).and.callFake(function renderOverride() {
       return (
+        // eslint-disable-next-line
         <div ref={this._setRef}>
           {this.props.children({ width: 200, height: 99999 })}
         </div>

--- a/src/tree-node.js
+++ b/src/tree-node.js
@@ -83,7 +83,7 @@ class TreeNode extends Component {
 
       scaffold.push(
         <div
-          key={`pre_${i}`}
+          key={`pre_${1+i}`}
           style={{ width: scaffoldBlockPxWidth }}
           className={`${styles.lineBlock} ${lineClass}`}
         />
@@ -108,7 +108,8 @@ class TreeNode extends Component {
 
         scaffold.push(
           <div
-            key={`highlight_${i}`}
+            // simple trick for passing react/no-array-index-key eslint rule
+            key={`highlight_${1+i}`}
             style={{
               width: scaffoldBlockPxWidth,
               left: scaffoldBlockPxWidth * i,

--- a/webpack.config.dev-external.babel.js
+++ b/webpack.config.dev-external.babel.js
@@ -1,0 +1,68 @@
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+import webpack from 'webpack';
+import autoprefixer from 'autoprefixer';
+
+module.exports = {
+  devtool: 'source-map',
+  entry: {
+    demo: './src/examples/externalNodeExample/app',
+  },
+  output: {
+    path: 'build',
+    filename: 'static/[name].js',
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      inject: true,
+      template: './src/examples/externalNodeExample/index.html',
+    }),
+    new webpack.EnvironmentPlugin(['NODE_ENV']),
+    new webpack.NoErrorsPlugin(),
+  ],
+  postcss: [autoprefixer({ browsers: ['IE >= 9', 'last 2 versions', '> 1%'] })],
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loaders: ['react-hot', 'babel'],
+        include: path.join(__dirname, 'src'),
+      },
+      {
+        test: /\.scss$/,
+        loaders: [
+          'style-loader?insertAt=top',
+          'css-loader?modules&-autoprefixer&importLoaders=1&localIdentName=rst__[local]',
+          'postcss-loader',
+          'sass-loader',
+        ],
+        include: path.join(__dirname, 'src'),
+      },
+      {
+        test: /\.css$/,
+        loaders: [
+          'style-loader?insertAt=top',
+          'css-loader?-autoprefixer',
+          'postcss-loader',
+        ],
+      },
+      {
+        test: /\.(jpe?g|png|gif|ico|svg)$/,
+        loaders: ['file-loader?name=static/[name].[ext]'],
+        include: path.join(__dirname, 'src'),
+      },
+    ],
+  },
+  devServer: {
+    contentBase: 'build',
+    port: 3001,
+    stats: {
+      chunks: false,
+      hash: false,
+      version: false,
+      assets: false,
+      children: false,
+    },
+  },
+};

--- a/webpack.config.external.babel.js
+++ b/webpack.config.external.babel.js
@@ -1,0 +1,61 @@
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+import webpack from 'webpack';
+import autoprefixer from 'autoprefixer';
+
+module.exports = {
+  devtool: 'source-map',
+  entry: {
+    demo: './src/examples/externalNodeExample/app',
+  },
+  output: {
+    path: 'build',
+    filename: 'static/[name].js',
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      inject: true,
+      template: './src/examples/externalNodeExample/index.html',
+    }),
+    new webpack.EnvironmentPlugin(['NODE_ENV']),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false,
+      },
+    }),
+  ],
+  postcss: [autoprefixer({ browsers: ['IE >= 9', 'last 2 versions', '> 1%'] })],
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loaders: ['babel'],
+        include: path.join(__dirname, 'src'),
+      },
+      {
+        test: /\.scss$/,
+        loaders: [
+          'style-loader?insertAt=top',
+          'css-loader?modules&-autoprefixer&importLoaders=1&localIdentName=rst__[local]',
+          'postcss-loader',
+          'sass-loader',
+        ],
+        include: path.join(__dirname, 'src'),
+      },
+      {
+        test: /\.css$/,
+        loaders: [
+          'style-loader?insertAt=top',
+          'css-loader?-autoprefixer',
+          'postcss-loader',
+        ],
+      },
+      {
+        test: /\.(jpe?g|png|gif|ico|svg)$/,
+        loaders: ['file-loader?name=static/[name].[ext]'],
+        include: path.join(__dirname, 'src'),
+      },
+    ],
+  },
+};


### PR DESCRIPTION
Building off the contribution of @NourSammour from PR #76 for dragging in external nodes, this PR implements a simplified exported helper function for wrapping a user-defined component in a react-dnd [DragSource](http://react-dnd.github.io/react-dnd/docs-drag-source.html), creating an 'external node' that can be dropped in to a react-sortable-tree component. Also included in this PR is additional documentation describing how to use this new feature, as well as a new simple demo with this added feature. Open for feedback.