### PR TITLE
Drag and drop between trees

### DIFF
--- a/examples/storybooks/__snapshots__/storyshots.test.js.snap
+++ b/examples/storybooks/__snapshots__/storyshots.test.js.snap
@@ -1,5 +1,647 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Advanced Drag and drop between Trees 1`] = `
+<div>
+  <div>
+    <div
+      style={
+        Object {
+          "borderBottom": "1px solid black ",
+          "height": 250,
+        }
+      }
+    >
+      <div
+        className="tree"
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
+      >
+        <div>
+          <div
+            aria-label="grid"
+            className="ReactVirtualized__Grid ReactVirtualized__List virtualScrollOverride"
+            id={undefined}
+            onScroll={[Function]}
+            role="grid"
+            style={
+              Object {
+                "WebkitOverflowScrolling": "touch",
+                "boxSizing": "border-box",
+                "direction": "ltr",
+                "height": 99999,
+                "overflowX": "hidden",
+                "overflowY": "hidden",
+                "position": "relative",
+                "width": 200,
+                "willChange": "transform",
+              }
+            }
+            tabIndex={0}
+          >
+            <div
+              className="ReactVirtualized__Grid__innerScrollContainer"
+              style={
+                Object {
+                  "height": 186,
+                  "maxHeight": 186,
+                  "maxWidth": 200,
+                  "overflow": "hidden",
+                  "pointerEvents": "",
+                  "position": "relative",
+                  "width": "auto",
+                }
+              }
+            >
+              <div
+                className="node"
+                style={
+                  Object {
+                    "height": 62,
+                    "left": 0,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="lineBlock lineHalfHorizontalRight lineHalfVerticalBottom"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="nodeContent"
+                  style={
+                    Object {
+                      "left": 44,
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "height": "100%",
+                      }
+                    }
+                  >
+                    <div>
+                      <button
+                        aria-label="Collapse"
+                        className="collapseButton"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "left": -22,
+                          }
+                        }
+                        type="button"
+                      />
+                      <div
+                        className="lineChildren"
+                        style={
+                          Object {
+                            "width": 44,
+                          }
+                        }
+                      />
+                    </div>
+                    <div
+                      className="rowWrapper"
+                    >
+                      <div
+                        className="row"
+                        style={
+                          Object {
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <div
+                          className="moveHandle"
+                        />
+                        <div
+                          className="rowContents"
+                        >
+                          <div
+                            className="rowLabel"
+                          >
+                            <span
+                              className="rowTitle rowTitleWithSubtitle"
+                            >
+                              node1
+                                ➞  path: [0] treeIndex: 0
+                            </span>
+                            <span
+                              className="rowSubtitle"
+                            >
+                              treeOne
+                            </span>
+                          </div>
+                          <div
+                            className="rowToolbar"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="node"
+                style={
+                  Object {
+                    "height": 62,
+                    "left": 0,
+                    "position": "absolute",
+                    "top": 62,
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="lineBlock lineFullVertical"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="lineBlock lineHalfVerticalTop lineHalfHorizontalRight"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="nodeContent"
+                  style={
+                    Object {
+                      "left": 88,
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "height": "100%",
+                      }
+                    }
+                  >
+                    <div
+                      className="rowWrapper"
+                    >
+                      <div
+                        className="row"
+                        style={
+                          Object {
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <div
+                          className="moveHandle"
+                        />
+                        <div
+                          className="rowContents"
+                        >
+                          <div
+                            className="rowLabel"
+                          >
+                            <span
+                              className="rowTitle rowTitleWithSubtitle"
+                            >
+                              child1
+                                ➞  path: [0,1] treeIndex: 1
+                            </span>
+                            <span
+                              className="rowSubtitle"
+                            >
+                              treeOne
+                            </span>
+                          </div>
+                          <div
+                            className="rowToolbar"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="node"
+                style={
+                  Object {
+                    "height": 62,
+                    "left": 0,
+                    "position": "absolute",
+                    "top": 124,
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="lineBlock lineHalfVerticalTop lineHalfHorizontalRight"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="nodeContent"
+                  style={
+                    Object {
+                      "left": 44,
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "height": "100%",
+                      }
+                    }
+                  >
+                    <div
+                      className="rowWrapper"
+                    >
+                      <div
+                        className="row"
+                        style={
+                          Object {
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <div
+                          className="moveHandle"
+                        />
+                        <div
+                          className="rowContents"
+                        >
+                          <div
+                            className="rowLabel"
+                          >
+                            <span
+                              className="rowTitle rowTitleWithSubtitle"
+                            >
+                              node2
+                                ➞  path: [2] treeIndex: 2
+                            </span>
+                            <span
+                              className="rowSubtitle"
+                            >
+                              treeOne
+                            </span>
+                          </div>
+                          <div
+                            className="rowToolbar"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "height": 250,
+        }
+      }
+    >
+      <div
+        className="tree"
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
+      >
+        <div>
+          <div
+            aria-label="grid"
+            className="ReactVirtualized__Grid ReactVirtualized__List virtualScrollOverride"
+            id={undefined}
+            onScroll={[Function]}
+            role="grid"
+            style={
+              Object {
+                "WebkitOverflowScrolling": "touch",
+                "boxSizing": "border-box",
+                "direction": "ltr",
+                "height": 99999,
+                "overflowX": "hidden",
+                "overflowY": "hidden",
+                "position": "relative",
+                "width": 200,
+                "willChange": "transform",
+              }
+            }
+            tabIndex={0}
+          >
+            <div
+              className="ReactVirtualized__Grid__innerScrollContainer"
+              style={
+                Object {
+                  "height": 186,
+                  "maxHeight": 186,
+                  "maxWidth": 200,
+                  "overflow": "hidden",
+                  "pointerEvents": "",
+                  "position": "relative",
+                  "width": "auto",
+                }
+              }
+            >
+              <div
+                className="node"
+                style={
+                  Object {
+                    "height": 62,
+                    "left": 0,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="lineBlock lineHalfHorizontalRight lineHalfVerticalBottom"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="nodeContent"
+                  style={
+                    Object {
+                      "left": 44,
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "height": "100%",
+                      }
+                    }
+                  >
+                    <div>
+                      <button
+                        aria-label="Collapse"
+                        className="collapseButton"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "left": -22,
+                          }
+                        }
+                        type="button"
+                      />
+                      <div
+                        className="lineChildren"
+                        style={
+                          Object {
+                            "width": 44,
+                          }
+                        }
+                      />
+                    </div>
+                    <div
+                      className="rowWrapper"
+                    >
+                      <div
+                        className="row"
+                        style={
+                          Object {
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <div
+                          className="moveHandle"
+                        />
+                        <div
+                          className="rowContents"
+                        >
+                          <div
+                            className="rowLabel"
+                          >
+                            <span
+                              className="rowTitle rowTitleWithSubtitle"
+                            >
+                              node1
+                                ➞  path: [0] treeIndex: 0
+                            </span>
+                            <span
+                              className="rowSubtitle"
+                            >
+                              treeTwo
+                            </span>
+                          </div>
+                          <div
+                            className="rowToolbar"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="node"
+                style={
+                  Object {
+                    "height": 62,
+                    "left": 0,
+                    "position": "absolute",
+                    "top": 62,
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="lineBlock lineFullVertical"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="lineBlock lineHalfVerticalTop lineHalfHorizontalRight"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="nodeContent"
+                  style={
+                    Object {
+                      "left": 88,
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "height": "100%",
+                      }
+                    }
+                  >
+                    <div
+                      className="rowWrapper"
+                    >
+                      <div
+                        className="row"
+                        style={
+                          Object {
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <div
+                          className="moveHandle"
+                        />
+                        <div
+                          className="rowContents"
+                        >
+                          <div
+                            className="rowLabel"
+                          >
+                            <span
+                              className="rowTitle rowTitleWithSubtitle"
+                            >
+                              child1
+                                ➞  path: [0,1] treeIndex: 1
+                            </span>
+                            <span
+                              className="rowSubtitle"
+                            >
+                              treeTwo
+                            </span>
+                          </div>
+                          <div
+                            className="rowToolbar"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="node"
+                style={
+                  Object {
+                    "height": 62,
+                    "left": 0,
+                    "position": "absolute",
+                    "top": 124,
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="lineBlock lineHalfVerticalTop lineHalfHorizontalRight"
+                  style={
+                    Object {
+                      "width": 44,
+                    }
+                  }
+                />
+                <div
+                  className="nodeContent"
+                  style={
+                    Object {
+                      "left": 44,
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "height": "100%",
+                      }
+                    }
+                  >
+                    <div
+                      className="rowWrapper"
+                    >
+                      <div
+                        className="row"
+                        style={
+                          Object {
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <div
+                          className="moveHandle"
+                        />
+                        <div
+                          className="rowContents"
+                        >
+                          <div
+                            className="rowLabel"
+                          >
+                            <span
+                              className="rowTitle rowTitleWithSubtitle"
+                            >
+                              node2
+                                ➞  path: [2] treeIndex: 2
+                            </span>
+                            <span
+                              className="rowSubtitle"
+                            >
+                              treeTwo
+                            </span>
+                          </div>
+                          <div
+                            className="rowToolbar"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <br />
+  <a
+    href="https://github.com/fritz-c/react-sortable-tree/tree/master/examples/storybooks/multiple-trees.js"
+    rel="noopener noreferrer"
+    target="_top"
+  >
+    View source
+  </a>
+</div>
+`;
+
 exports[`Storyshots Advanced Drag from external source 1`] = `
 <div>
   <div>
@@ -113,6 +755,7 @@ exports[`Storyshots Advanced Drag from external source 1`] = `
                               className="rowTitle"
                             >
                               node1
+                                ➞  path: [0] treeIndex: 0
                             </span>
                           </div>
                           <div
@@ -183,6 +826,7 @@ exports[`Storyshots Advanced Drag from external source 1`] = `
                               className="rowTitle"
                             >
                               node2
+                                ➞  path: [1] treeIndex: 1
                             </span>
                           </div>
                           <div
@@ -366,6 +1010,7 @@ exports[`Storyshots Advanced Touch support (Experimental) 1`] = `
                               className="rowTitle"
                             >
                               Chicken
+                                ➞  path: [0] treeIndex: 0
                             </span>
                           </div>
                           <div
@@ -444,6 +1089,7 @@ exports[`Storyshots Advanced Touch support (Experimental) 1`] = `
                               className="rowTitle"
                             >
                               Egg
+                                ➞  path: [0,1] treeIndex: 1
                             </span>
                           </div>
                           <div
@@ -585,6 +1231,7 @@ exports[`Storyshots Basics Add and remove nodes programmatically 1`] = `
                               className="rowTitle"
                             >
                               Peter Olofsson
+                                ➞  path: [0] treeIndex: 0
                             </span>
                           </div>
                           <div
@@ -674,6 +1321,7 @@ exports[`Storyshots Basics Add and remove nodes programmatically 1`] = `
                               className="rowTitle"
                             >
                               Karl Johansson
+                                ➞  path: [1] treeIndex: 1
                             </span>
                           </div>
                           <div
@@ -859,6 +1507,7 @@ exports[`Storyshots Basics Minimal implementation 1`] = `
                             className="rowTitle"
                           >
                             Chicken
+                              ➞  path: [0] treeIndex: 0
                           </span>
                         </div>
                         <div
@@ -937,6 +1586,7 @@ exports[`Storyshots Basics Minimal implementation 1`] = `
                             className="rowTitle"
                           >
                             Egg
+                              ➞  path: [0,1] treeIndex: 1
                           </span>
                         </div>
                         <div

--- a/examples/storybooks/index.js
+++ b/examples/storybooks/index.js
@@ -7,6 +7,7 @@ import BarebonesExample from './barebones';
 import AddRemoveExample from './add-remove';
 import ExternalNodeExample from './external-node';
 import TouchSupportExample from './touch-support';
+import MultipleTrees from './multiple-trees'
 
 const wrapWithSource = (node, src) =>
   <div>
@@ -36,4 +37,7 @@ storiesOf('Advanced', module)
   )
   .add('Touch support (Experimental)', () =>
     wrapWithSource(<TouchSupportExample />, 'touch-support.js')
+  )
+  .add('Drag and drop between Trees', () =>
+    wrapWithSource(<MultipleTrees />, 'multiple-trees.js')
   );

--- a/examples/storybooks/multiple-trees.js
+++ b/examples/storybooks/multiple-trees.js
@@ -1,0 +1,90 @@
+import React, { Component } from 'react';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import {
+  SortableTreeWithoutDndContext as SortableTree,
+} from '../../src';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+
+    this.dropCancelled = this.dropCancelled.bind(this)
+
+    this.state = {
+      treeDataOne: [
+        { 
+          title: 'node1', 
+          subtitle: 'treeOne', 
+          expanded: true,
+          children: [
+            { 
+              title: 'child1', 
+              subtitle: 'treeOne'
+            }
+          ] 
+        }, 
+        { 
+          title: 'node2', 
+          subtitle: 'treeOne' 
+        }
+      ],
+      treeDataTwo: [
+        { 
+          title: 'node1', 
+          subtitle: 'treeTwo',
+          expanded: true,
+          children: [
+            { 
+              title: 'child1', 
+              subtitle: 'treeTwo'
+            }
+          ] 
+        }, 
+        { 
+          title: 'node2', 
+          subtitle: 'treeTwo' 
+        }
+      ],
+    };
+  }
+
+  dropCancelled () {
+    // cancels drop event for ALL trees if no current valid dropTargets
+    // this is nothing more than the typical onChange prop you'd normally give an RST tree,
+    // but is designed for all trees that can interact, meaning multiple trees with the same
+    // dndType prop
+    this.setState(state => ({
+      treeDataOne: state.treeDataOne.concat(),
+      treeDataTwo: state.treeDataTwo.concat(),
+    }))
+  }
+
+
+  render() {
+    return (
+      <div>
+        <div style={{ height: 250, borderBottom: '1px solid black ' }}>
+          <SortableTree
+            treeData={this.state.treeDataOne}
+            onChange={treeDataOne => this.setState({ treeDataOne })}
+            dndType={'SAME_DND_TYPE'}
+            // single new prop for multi-trees feature         
+            dropCancelled={this.dropCancelled}  
+          />
+        </div>
+        <div style={{ height: 250 }}>
+          <SortableTree
+            treeData={this.state.treeDataTwo}
+            onChange={treeDataTwo => this.setState({ treeDataTwo })}
+            dndType={'SAME_DND_TYPE'}
+            // single new prop for multi-trees feature
+            dropCancelled={this.dropCancelled}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default DragDropContext(HTML5Backend)(App);

--- a/src/__snapshots__/react-sortable-tree.test.js.snap
+++ b/src/__snapshots__/react-sortable-tree.test.js.snap
@@ -102,7 +102,9 @@ exports[`<SortableTree /> should render tree correctly 1`] = `
                     >
                       <span
                         className="rowTitle"
-                      />
+                      >
+                          ➞  path: [0] treeIndex: 0
+                      </span>
                     </div>
                     <div
                       className="rowToolbar"

--- a/src/node-renderer-default.js
+++ b/src/node-renderer-default.js
@@ -36,7 +36,9 @@ class NodeRendererDefault extends Component {
       className,
       style,
       didDrop,
+      treeID,
       /* eslint-disable no-unused-vars */
+      dropCancelled: _dropCancelled,
       isOver: _isOver, // Not needed, but preserved for other renderers
       parentNode: _parentNode, // Needed for drag-and-drop utils
       endDrag: _endDrag, // Needed for drag-and-drop utils
@@ -149,6 +151,7 @@ class NodeRendererDefault extends Component {
                           treeIndex,
                         })
                       : node.title}
+                      {`  \u279E  path: [${path}] treeIndex: ${treeIndex}`}
                   </span>
 
                   {node.subtitle &&
@@ -193,6 +196,7 @@ NodeRendererDefault.defaultProps = {
   parentNode: null,
   draggedNode: null,
   canDrop: false,
+  dropCancelled: null
 };
 
 NodeRendererDefault.propTypes = {
@@ -209,6 +213,7 @@ NodeRendererDefault.propTypes = {
   buttons: PropTypes.arrayOf(PropTypes.node),
   className: PropTypes.string,
   style: PropTypes.shape({}),
+  treeID: PropTypes.string.isRequired,
 
   // Drag and drop API functions
   // Drag source
@@ -219,6 +224,7 @@ NodeRendererDefault.propTypes = {
   endDrag: PropTypes.func.isRequired, // Needed for drag-and-drop utils
   isDragging: PropTypes.bool.isRequired,
   didDrop: PropTypes.bool.isRequired,
+  dropCancelled: PropTypes.func,
   draggedNode: PropTypes.shape({}),
   // Drop target
   isOver: PropTypes.bool.isRequired,

--- a/src/tree-node.js
+++ b/src/tree-node.js
@@ -17,7 +17,9 @@ class TreeNode extends Component {
       draggedNode,
       canDrop,
       treeIndex,
+      treeID,
       /* eslint-disable no-unused-vars */
+      dropOnOtherTree,
       customCanDrop: _customCanDrop, // Delete from otherProps
       dragHover: _dragHover, // Delete from otherProps
       getNodeKey: _getNodeKey, // Delete from otherProps
@@ -166,12 +168,14 @@ TreeNode.propTypes = {
 
   listIndex: PropTypes.number.isRequired,
   children: PropTypes.node.isRequired,
+  treeID: PropTypes.string.isRequired,
 
   // Drop target
   connectDropTarget: PropTypes.func.isRequired,
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool,
   draggedNode: PropTypes.shape({}),
+  dropOnOtherTree: PropTypes.func.isRequired,
 
   customCanDrop: PropTypes.func, // used in drag-and-drop-utils
   dragHover: PropTypes.func.isRequired, // used in drag-and-drop-utils


### PR DESCRIPTION
This PR addresses issues #132 and #118, and implements dragging and dropping between more than one tree. Docs and storybook examples have been updated to illustrate how to use. The only requirement to enable this feature is to supply all drag and droppable trees with the same `dndType` and the same `dropCancelled` container component method. This `dropCancelled` method is still optional for single-tree container components and this feature supports the recent external node handling feature. The `dropCancelled` method is essentially the same `onChange` prop method supplied to individual trees, but instead it handles _all_ treeData objects of _all_ interactable trees, for all trees that could be impacted by an invalid node drop event. Feedback is welcome.