### PR TITLE
toggleChildrenVisibility isn't passing onVisibilityToggle up-to-date data

### DIFF
--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -161,7 +161,7 @@ class ReactSortableTree extends Component {
 
     this.props.onVisibilityToggle({
       treeData,
-      node: targetNode,
+      node: { ...targetNode, expanded: !targetNode.expanded },
       expanded: !targetNode.expanded,
       path,
     });


### PR DESCRIPTION
@fritz-c 

Currently, toggleChildrenVisibility calls this.props.onVisibilityToggle. However before this, it updates the nodes expanded property and does not send the updated node to the props.

This could be code duplication, however if a user wants to update the tree using onVisibilityToggle they will have to create a new node anyways with the current expanded property. If they don't, the tree will be out of sync.
