### PR TITLE
fix: recalculate rowHeight() when isVirualized

### DIFF
--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -235,6 +235,8 @@ class ReactSortableTree extends Component {
       getNodeKey: this.props.getNodeKey,
     });
 
+    this.scrollZoneVirtualListComponent.wrappedInstance.recomputeRowHeights();
+
     this.props.onChange(treeData);
 
     this.props.onMoveNode({
@@ -634,6 +636,9 @@ class ReactSortableTree extends Component {
           {({ height, width }) => (
             <ScrollZoneVirtualList
               {...scrollToInfo}
+    				  ref={el => {
+                this.scrollZoneVirtualListComponent = el
+              }}
               verticalStrength={this.vStrength}
               horizontalStrength={this.hStrength}
               speed={30}


### PR DESCRIPTION
When rendering rows with isVirualized, if rowHeight is a func, the
virtualized list was not recalculating the rowHeight.
Per the `react-virtualized` docs
[here](https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#recomputerowheights-index-number), `List.recomputeRowHeights()`
needs to be called.

This only fixes the dynamic rowHeight issue _after_ dragging a node is
finished.  An additional `List.recomputeRowHeights()` will need to be
called to fix the ‘preview’ while dragging a row (see issue below for
more details).

This partially fixes [Issue 264](https://github.com/fritz-c/react-sortable-tree/issues/264).